### PR TITLE
Bump Traefik to version 1.7.9

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.6.5_linux-amd64.gz:
-  size: 14386020
-  object_id: 89f33f41-ab7b-4dc3-6af8-97577983d043
-  sha: b449562715bc41820a126d2fced7a12d6692b9cc
+traefik/traefik-1.7.9_linux-amd64.gz:
+  size: 19425802
+  sha: 97680a83acf40152be11b100b5e98307149c7c1c

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.9_linux-amd64.gz:
   size: 19425802
+  object_id: bee8432a-c9ee-4f77-56fc-5a62358c3382
   sha: 97680a83acf40152be11b100b5e98307149c7c1c

--- a/deployment/operations/enable-api.yml
+++ b/deployment/operations/enable-api.yml
@@ -1,0 +1,36 @@
+---
+
+- path: /instance_groups/name=traefik/jobs/name=traefik/properties/traefik?/api
+  type: replace
+  value:
+    enabled: true
+    digest_auth:
+      username: ((api_username))
+      password: ((api_password))
+    tls:
+      port: 8443
+      cert: ((api_tls))
+
+- path: /variables?/name=api_password
+  type: replace
+  value:
+    name: api_password
+    type: password
+
+- path: /variables?/name=traefikCA
+  type: replace
+  value:
+    name: traefikCA
+    type: certificate
+    options:
+      is_ca: true
+      common_name: traefikCA
+
+- path: /variables?/name=api_tls
+  type: replace
+  value:
+    name: api_tls
+    type: certificate
+    options:
+      ca: traefikCA
+      common_name: api_tls

--- a/jobs/traefik/spec
+++ b/jobs/traefik/spec
@@ -11,6 +11,8 @@ templates:
   tls/traefik-default.key: tls/traefik-default.key
   tls/web-backend.crt: tls/web-backend.crt
   tls/web-backend.key: tls/web-backend.key
+  tls/api-entrypoint.crt: tls/api-entrypoint.crt
+  tls/api-entrypoint.key: tls/api-entrypoint.key
 
 packages:
   - traefik
@@ -19,6 +21,15 @@ properties:
   traefik.debug:
     description: |
       Whether to enable debug mode.
+
+      This mode should never be enabled in production because it exposes
+      internal state of the Traefik server that malicious users should not have
+      access to.
+
+      This will install HTTP handlers to expose Go expvars under /debug/vars
+      and pprof profiling data under /debug/pprof.
+
+      The log level will be set to DEBUG unless 'log_level' is specified.
     default: false
   traefik.log_level:
     description: |
@@ -35,7 +46,7 @@ properties:
   traefik.access_logs.enabled:
     description: |
       Whether to activate the access logs. This will produce one line for each
-      access to the traefik server. This might generate high volume of data
+      access to the Traefik server. This might generate high volume of data
       under high loads.
     default: true
 
@@ -47,14 +58,21 @@ properties:
       on trusted backend networks only.
     default: false
 
+
   traefik.http.enabled:
     description: |
       Whether to activate the HTTP entrypoint.
-    default: false
+    default: true
   traefik.http.port:
     description: |
       TCP port for the HTTP entrypoint.
     default: 80
+  traefik.http.redirect_to_https:
+    description: |
+      Whether the HTTP entrypoint redirects all web requests to the HTTPS
+      entrypoint or not.
+    default: true
+
 
   traefik.tls.enabled:
     description: |
@@ -68,12 +86,16 @@ properties:
     type: certificate
     description: |
       The default TLS certificate to present on HTTPS entrypoint.
+  traefik.tls.min_version:
+    description: |
+      The minimum TLS version to be used by the HTTPS entrypoint.
+    default: VersionTLS12
+
 
   traefik.acme.enabled:
     description: |
       Whether to activate automatic Let's Encrypt certificates.
     default: false
-
   traefik.acme.certs_email:
     description: |
       Email address used for ACME certificate registration.
@@ -83,7 +105,6 @@ properties:
       certificates before they actually expire. So you usually need not take
       action uppon receiving expiration notice when running Traefik.
     example: acme-certs-contact@example.com
-
   traefik.acme.staging:
     description: |
       Run on the staging Let's Encrypt server.
@@ -95,8 +116,48 @@ properties:
       the production server.
     default: true
 
+
+  traefik.api.enabled:
+    description: |
+      Whether the Traefik API and Dashboard should be enabled.
+
+      This will enable:
+        - A REST API endpoint.
+        - A web UI that can be used to dynamically read or modify the Traefik
+          configuration.
+        - A '/ping' endpoint for healthchecks.
+        - A metrics endpoint for Prometheus to scrape.
+
+      This BOSH Release only serves API and Dashboard on a TLS endpoint
+      protected by a Digest Auth username and password.
+
+      Please take care not exposing this endpoint to the entire Internet,
+      otherwise your server could get compromized by malicious users.
+    default: false
+  traefik.api.tls.port:
+    description: |
+      TCP port for the Traefik API and Dashboard.
+    default: 8443
+  traefik.api.tls.cert:
+    type: certificate
+    description: |
+      The TLS certificate to use for the API and Dashboard entrypoint.
+  traefik.api.tls.min_version:
+    description: |
+      The minimum TLS version to be used by the API and Dashboard entrypoint.
+    default: VersionTLS12
+  traefik.api.digest_auth.username:
+    description: |
+      Digest Auth username to access the Traefik API and Dashboard.
+  traefik.api.digest_auth.password:
+    description: |
+      Digest Auth password to access the Traefik API and Dashboard.
+
+
   traefik.web.enabled:
     description: |
+      DEPRECATED. See 'traefik.api.*' properties instead.
+
       Whether the 'web' backend should be enabled.
 
       This will enable a REST API endpoint and a web UI that can be used to
@@ -106,9 +167,13 @@ properties:
     default: false
   traefik.web.basic_auth.username:
     description: |
+      DEPRECATED. See 'traefik.api.*' properties instead.
+
       Basic Auth username to access the 'web' backend.
   traefik.web.basic_auth.password:
     description: |
+      DEPRECATED. See 'traefik.api.*' properties instead.
+
       Basic Auth password to access the 'web' backend.
 
       This value will end up being (kind of) MD5-digested (like 'htpasswd'
@@ -116,11 +181,15 @@ properties:
       clear-text on the BOSH-managed Traefik nodes.
   traefik.web.readonly:
     description: |
+      DEPRECATED. See 'traefik.api.*' properties instead.
+
       Whether the 'web' endpoint should be readonly, in which case the Traefik
       configuration can only be read and not modified through this backend.
     default: true
   traefik.web.port:
     description: |
+      DEPRECATED. See 'traefik.api.*' properties instead.
+
       TCP port for the 'web' backend.
 
       We advise to set '8443' here when 'traefik.web.tls.enabled' is set to
@@ -128,12 +197,17 @@ properties:
     default: 8080
   traefik.web.tls.enabled:
     description: |
+      DEPRECATED. See 'traefik.api.*' properties instead.
+
       Whether to activate TLS for the 'web' backend.
     default: false
   traefik.web.tls.cert:
     type: certificate
     description: |
+      DEPRECATED. See 'traefik.api.*' properties instead.
+
       The TLS certificate to use for the 'web' backend.
+
 
   traefik.file.enabled:
     description: |

--- a/jobs/traefik/templates/conf/traefik.toml
+++ b/jobs/traefik/templates/conf/traefik.toml
@@ -112,19 +112,39 @@
       return encoded_password
     end
 
+
+    # ----------------------------------------------------------- #
+    # The following code is pulled out htauth's 'digest_entry.rb' #
+    # ----------------------------------------------------------- #
+
+
+    # Internal: calculate the new digest of the given password
+    def calc_digest(user, realm, password)
+      ::Digest::MD5.hexdigest("#{user}:#{realm}:#{password}")
+    end
+
 -%>
 ################################################################
 # Global configuration
 ################################################################
 
-# Duration to give active requests a chance to finish before Traefik stops.
+# DEPRECATED - for general usage instruction see [lifeCycle.graceTimeOut].
+#
+# If both the deprecated option and the new one are given, the deprecated one
+# takes precedence.
+# A value of zero is equivalent to omitting the parameter, causing
+# [lifeCycle.graceTimeOut] to be effective. Pass zero to the new option in
+# order to disable the grace period.
 #
 # Optional
-# Default: "10s"
+# Default: "0s"
 #
 # graceTimeOut = "10s"
 
 # Enable debug mode.
+# This will install HTTP handlers to expose Go expvars under /debug/vars and
+# pprof profiling data under /debug/pprof/.
+# The log level will be set to DEBUG unless `logLevel` is specified.
 #
 # Optional
 # Default: false
@@ -138,19 +158,26 @@ debug = <%= p('traefik.debug') %>
 #
 # checkNewVersion = false
 
-# Backends throttle duration.
+# Tells traefik whether it should keep the trailing slashes in the paths (e.g. /paths/) or redirect to the no trailing slash paths instead (/paths).
+#
+# Optional
+# Default: false
+#
+# keepTrailingSlash = false
+
+# Providers throttle duration.
 #
 # Optional
 # Default: "2s"
 #
-# ProvidersThrottleDuration = "2s"
+# providersThrottleDuration = "2s"
 
 # Controls the maximum idle (keep-alive) connections to keep per-host.
 #
 # Optional
 # Default: 200
 #
-# MaxIdleConnsPerHost = 200
+# maxIdleConnsPerHost = 200
 
 # If set to true invalid SSL certificates are accepted for backends.
 # This disables detection of man-in-the-middle attacks so should only be used on secure backend networks.
@@ -160,12 +187,12 @@ debug = <%= p('traefik.debug') %>
 #
 InsecureSkipVerify = <%= p('traefik.accept_invalid_backend_certificates') %>
 
-# Register Certificates in the RootCA.
+# Register Certificates in the rootCA.
 #
 # Optional
 # Default: []
 #
-# RootCAs = [ "/mycert.cert" ]
+# rootCAs = [ "/mycert.cert" ]
 
 # Entrypoints to be used by frontends that do not specify any entrypoint.
 # Each frontend can specify its own entrypoints.
@@ -174,6 +201,195 @@ InsecureSkipVerify = <%= p('traefik.accept_invalid_backend_certificates') %>
 # Default: ["http"]
 #
 # defaultEntryPoints = ["http", "https"]
+
+# Allow the use of 0 as server weight.
+# - false: a weight 0 means internally a weight of 1.
+# - true: a weight 0 means internally a weight of 0 (a server with a weight of 0 is removed from the available servers).
+#
+# Optional
+# Default: false
+#
+# AllowMinWeightZero = true
+
+
+# Enable retry sending request if network error
+[retry]
+
+# Number of attempts
+#
+# Optional
+# Default: (number servers in backend) -1
+#
+# attempts = 3
+
+
+# Enable custom health check options.
+[healthcheck]
+
+# Set the default health check interval.
+#
+# Optional
+# Default: "30s"
+#
+# interval = "30s"
+
+
+# Control the behavior of Traefik during the shutdown phase.
+[lifeCycle]
+
+# Duration to keep accepting requests prior to initiating the graceful
+# termination period (as defined by the `graceTimeOut` option). This
+# option is meant to give downstream load-balancers sufficient time to
+# take Traefik out of rotation.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw values (digits).
+# If no units are provided, the value is parsed assuming seconds.
+# The zero duration disables the request accepting grace period, i.e.,
+# Traefik will immediately proceed to the grace period.
+#
+# Optional
+# Default: 0
+#
+# requestAcceptGraceTimeout = "10s"
+
+# Duration to give active requests a chance to finish before Traefik stops.
+# Can be provided in a format supported by [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) or as raw values (digits).
+# If no units are provided, the value is parsed assuming seconds.
+# Note: in this time frame no new requests are accepted.
+#
+# Optional
+# Default: "10s"
+#
+# graceTimeOut = "10s"
+
+
+[respondingTimeouts]
+
+# readTimeout is the maximum duration for reading the entire request, including the body.
+#
+# Optional
+# Default: "0s"
+#
+# readTimeout = "5s"
+
+# writeTimeout is the maximum duration before timing out writes of the response.
+#
+# Optional
+# Default: "0s"
+#
+# writeTimeout = "5s"
+
+# idleTimeout is the maximum duration an idle (keep-alive) connection will remain idle before closing itself.
+#
+# Optional
+# Default: "180s"
+#
+# idleTimeout = "360s"
+
+
+[forwardingTimeouts]
+
+# dialTimeout is the amount of time to wait until a connection to a backend server can be established.
+#
+# Optional
+# Default: "30s"
+#
+# dialTimeout = "30s"
+
+# responseHeaderTimeout is the amount of time to wait for a server's response headers after fully writing the request (including its body, if any).
+#
+# Optional
+# Default: "0s"
+#
+# responseHeaderTimeout = "0s"
+
+
+
+# idleTimeout
+#
+# DEPRECATED - see [respondingTimeouts] section.
+#
+# Optional
+# Default: "180s"
+#
+# idleTimeout = "360s"
+
+
+[hostResolver]
+
+# cnameFlattening is a trigger to flatten request host, assuming it is a CNAME record
+#
+# Optional
+# Default : false
+#
+# cnameFlattening = true
+
+# resolvConf is dns resolving configuration file, the default is /etc/resolv.conf
+#
+# Optional
+# Default : "/etc/resolv.conf"
+#
+# resolvConf = "/etc/resolv.conf"
+
+# resolvDepth is the maximum CNAME recursive lookup
+#
+# Optional
+# Default : 5
+#
+# resolvDepth = 5
+
+
+
+
+################################################################
+# Entrypoints configuration
+################################################################
+
+# Entrypoints definition
+#
+# Optional
+
+[entryPoints]
+<% if p('traefik.http.enabled') -%>
+  [entryPoints.http]
+  address = ":80"
+<%   if p('traefik.http.redirect_to_https') -%>
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+<%   end -%>
+<% end -%>
+<% if p('traefik.tls.enabled') -%>
+  [entryPoints.https]
+  address = ":443"
+    [entryPoints.https.tls]
+    minVersion = "<%= p('traefik.tls.min_version') %>"
+<%   if_p('traefik.tls.cert') do |cert| -%>
+      [[entryPoints.https.tls.certificates]]
+      CertFile = "/var/vcap/jobs/traefik/tls/traefik-default.crt"
+      KeyFile = "/var/vcap/jobs/traefik/tls/traefik-default.key"
+<%   end -%>
+<% end -%>
+
+<% if p('traefik.api.enabled') -%>
+  [entryPoints.traefik-api]
+  address = ":<%= p('traefik.api.tls.port') %>"
+    [entryPoints.traefik-api.auth]
+      [entryPoints.traefik-api.auth.digest]
+      users = [
+<%
+    username = p('traefik.api.digest_auth.username')
+    realm = "traefik"
+    digest = calc_digest(username, realm, p('traefik.api.digest_auth.password'))
+-%>
+        "<%= "#{username}:#{realm}:#{digest}" %>"
+      ]
+<%     if_p('traefik.api.tls.cert') do |cert| -%>
+    [entryPoints.traefik-api.tls]
+      minVersion = "<%= p('traefik.api.tls.min_version') %>"
+      [[entryPoints.traefik-api.tls.certificates]]
+      certFile = "/var/vcap/jobs/traefik/tls/api-entrypoint.crt"
+      keyFile = "/var/vcap/jobs/traefik/tls/api-entrypoint.key"
+<%     end -%>
+<% end -%>
 
 
 
@@ -191,18 +407,27 @@ InsecureSkipVerify = <%= p('traefik.accept_invalid_backend_certificates') %>
 #
 logLevel = "<%= p('traefik.log_level') %>"
 
-# Traefik logs file
-# If not defined, logs to stdout
+# Traefik logs
+# Enabled by default and log to stdout
 #
 # Optional
 #
-traefikLogsFile = "/var/vcap/data/sys/log/traefik/traefik.log"
+[traefikLog]
 
-# NOTE: after version 1.4.6, the new [traefikLog] section is introduced.
-# See:
-#   <https://github.com/containous/traefik/blob/837db9a/traefik.sample.toml#L35-L55>
-# Compared to:
-#   <https://github.com/containous/traefik/blob/v1.4.6/traefik.sample.toml#L12-L24>
+# Sets the filepath for the traefik log. If not specified, stdout will be used.
+# Intermediate directories are created if necessary.
+#
+# Optional
+# Default: os.Stdout
+#
+filePath = "/var/vcap/data/sys/log/traefik/traefik.log"
+
+# Format is either "json" or "common".
+#
+# Optional
+# Default: "common"
+#
+# format = "common"
 
 
 
@@ -233,29 +458,225 @@ filePath = "/var/vcap/data/sys/log/traefik/access.log"
 # Default: "common"
 #
 # format = "common"
+
+  [accessLog.filters]
+
+  # statusCodes: keep access logs with status codes in the specified range
+  #
+  # Optional
+  # Default: []
+  #
+  # statusCodes = ["200", "300-302"]
+
+  # retryAttempts: keep access logs when at least one retry happened
+  #
+  # Optional
+  # Default: false
+  #
+  # retryAttempts = true
+
+  # minDuration: keep access logs when request took longer than the specified duration
+  #
+  # Optional
+  # Default: 0
+  #
+  # minDuration = "10ms"
+
+  [accessLog.fields]
+
+  # defaultMode
+  #
+  # Optional
+  # Default: "keep"
+  #
+  # Accepted values "keep", "drop"
+  #
+  defaultMode = "keep"
+
+  # Fields map which is used to override fields defaultMode
+  [accessLog.fields.names]
+    # "ClientUsername" = "drop"
+    # ...
+
+  [accessLog.fields.headers]
+    # defaultMode
+    #
+    # Optional
+    # Default: "keep"
+    #
+    # Accepted values "keep", "drop", "redact"
+    #
+    defaultMode = "keep"
+    # Fields map which is used to override headers defaultMode
+    [accessLog.fields.headers.names]
+      # "User-Agent" = "redact"
+      # "Authorization" = "drop"
+      # "Content-Type" = "keep"
+      # ...
+
 <% end -%>
+
+
+
+<% if p('traefik.api.enabled') -%>
+################################################################
+# API and dashboard configuration
+################################################################
+
+# API definition
+# Warning: Enabling API will expose Traefik's configuration.
+# It is not recommended in production,
+# unless secured by authentication and authorizations
+[api]
+
+  # Name of the related entry point
+  #
+  # Optional
+  # Default: "traefik"
+  #
+  entryPoint = "traefik-api"
+
+  # Enable Dashboard
+  #
+  # Optional
+  # Default: true
+  #
+  dashboard = true
+
+  # Enable debug mode.
+  # This will install HTTP handlers to expose Go expvars under /debug/vars and
+  # pprof profiling data under /debug/pprof/.
+  # Additionally, the log level will be set to DEBUG.
+  #
+  # Optional
+  # Default: false
+  #
+  # debug = true
+
+  # Enable more detailed statistics.
+  [api.statistics]
+
+    # Number of recent errors logged.
+    #
+    # Default: 10
+    #
+    recentErrors = 10
 
 
 
 ################################################################
-# Entry Points configuration
+# Ping configuration
 ################################################################
 
-[entryPoints]
-<% if p('traefik.http.enabled') -%>
-  [entryPoints.http]
-  address = ":80"
+# Ping definition
+[ping]
+
+  # Name of the related entry point
+  #
+  # Optional
+  # Default: "traefik"
+  #
+  entryPoint = "traefik-api"
+
+
+
+################################################################
+# Metrics configuration
+################################################################
+
+# Metrics definition
+[metrics]
+
+  # To enable Traefik to export internal metrics to Prometheus
+  [metrics.prometheus]
+
+    # Name of the related entry point
+    #
+    # Optional
+    # Default: "traefik"
+    #
+    entryPoint = "traefik-api"
+
+    # Buckets for latency metrics
+    #
+    # Optional
+    # Default: [0.1, 0.3, 1.2, 5.0]
+    #
+    buckets = [0.1, 0.3, 1.2, 5.0]
+
+  # DataDog metrics exporter type
+  # [metrics.datadog]
+
+    # DataDog's address.
+    #
+    # Required
+    # Default: "localhost:8125"
+    #
+    # address = "localhost:8125"
+
+    # DataDog push interval
+    #
+    # Optional
+    # Default: "10s"
+    #
+    # pushInterval = "10s"
+
+  # StatsD metrics exporter type
+  # [metrics.statsd]
+
+    # StatD's address.
+    #
+    # Required
+    # Default: "localhost:8125"
+    #
+    # address = "localhost:8125"
+
+    # StatD push interval
+    #
+    # Optional
+    # Default: "10s"
+    #
+    # pushInterval = "10s"
+
+  # InfluxDB metrics exporter type
+  # [metrics.influxdb]
+
+    # InfluxDB's address.
+    #
+    # Required
+    # Default: "localhost:8089"
+    #
+    # address = "localhost:8089"
+
+    # InfluxDB's address protocol (udp or http)
+    #
+    # Required
+    # Default: "udp"
+    #
+    # protocol = "udp"
+
+    # InfluxDB push interval
+    #
+    # Optional
+    # Default: "10s"
+    #
+    # pushinterval = "10s"
+
+    # InfluxDB database used when protocol is http
+    #
+    # Optional
+    # Default: ""
+    #
+    # database = ""
+
+    # InfluxDB retention policy used when protocol is http
+    #
+    # Optional
+    # Default: ""
+    #
+    # retentionpolicy = ""
 <% end -%>
-<% if p('traefik.tls.enabled') -%>
-  [entryPoints.https]
-  address = ":443"
-<% if_p('traefik.tls.cert') do |cert| -%>
-    [entryPoints.https.tls]
-      [[entryPoints.https.tls.certificates]]
-      CertFile = "/var/vcap/jobs/traefik/tls/traefik-default.crt"
-      KeyFile = "/var/vcap/jobs/traefik/tls/traefik-default.key"
-<% end -%>
-<% end -%>
+
 
 
 
@@ -277,79 +698,89 @@ email = "<%= p('traefik.acme.certs_email') %>"
 #
 # storage = "acme.json"
 # or `storage = "traefik/acme/account"` if using KV store.
-<% if p('traefik.acme.staging') -%>
+<%   if p('traefik.acme.staging') -%>
 storage = "/var/vcap/store/traefik/acme/acme-staging-data.json"
-<% else -%>
+<%   else -%>
 storage = "/var/vcap/store/traefik/acme/acme-data.json"
-<% end -%>
+<%   end -%>
 
-# Entrypoint to proxy acme challenge/apply certificates to.
+# Entrypoint to proxy acme apply certificates to.
 # WARNING, must point to an entrypoint on port 443
 #
 # Required
 #
 entryPoint = "https"
 
-# Use a DNS based acme challenge rather than external HTTPS access
+# Deprecated, replaced by [acme.dnsChallenge].
 #
-#
-# Optional
+# Optional.
 #
 # dnsProvider = "digitalocean"
 
-# By default, the dnsProvider will verify the TXT DNS challenge record before letting ACME verify.
-# If delayDontCheckDNS is greater than zero, avoid this & instead just wait so many seconds.
-# Useful if internal networks block external DNS queries.
+# Deprecated, replaced by [acme.dnsChallenge.delayBeforeCheck].
 #
 # Optional
+# Default: 0
 #
 # delayDontCheckDNS = 0
 
 # If true, display debug log messages from the acme client library.
 #
 # Optional
+# Default: false
 #
 acmeLogging = true
 
-# Enable on demand certificate.
+# If true, override certificates in key-value store when using storeconfig.
 #
 # Optional
+# Default: false
+#
+# overrideCertificates = true
+
+# Deprecated. Enable on demand certificate generation.
+#
+# Optional
+# Default: false
 #
 onDemand = true
 
-# Enable certificate generation on frontends Host rules.
+# Enable certificate generation on frontends host rules.
 #
 # Optional
+# Default: false
 #
 # onHostRule = true
 
 # CA server to use.
-# - Uncomment the line to run on the staging let's encrypt server.
-# - Leave comment to go to prod.
+# Uncomment the line to use Let's Encrypt's staging server,
+# leave commented to go to prod.
 #
 # Optional
+# Default: "https://acme-v02.api.letsencrypt.org/directory"
 #
-# caServer = "https://acme-staging.api.letsencrypt.org/directory"
-<% if p('traefik.acme.staging') -%>
-caServer = "https://acme-staging.api.letsencrypt.org/directory"
-<% end -%>
+<%   if p('traefik.acme.staging') -%>
+caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
+<%   end -%>
 
-# Domains list.
+# KeyType to use.
 #
-# [[acme.domains]]
-# main = "local1.com"
-# sans = ["test1.local1.com", "test2.local1.com"]
-# [[acme.domains]]
-# main = "local2.com"
-# sans = ["test1.local2.com", "test2.local2.com"]
-# [[acme.domains]]
-# main = "local3.com"
-# [[acme.domains]]
-# main = "local4.com"
+# Optional
+# Default: "RSA4096"
+#
+# Available values : "EC256", "EC384", "RSA2048", "RSA4096", "RSA8192"
+#
+KeyType = "RSA4096"
+
+# Use a TLS-ALPN-01 ACME challenge.
+#
+# Optional (but recommended)
+#
+# [acme.tlsChallenge]
 
 # Use a HTTP-01 ACME challenge.
 #
-# Optional (but recommended)
+# Optional
 #
 [acme.httpChallenge]
 
@@ -358,6 +789,58 @@ caServer = "https://acme-staging.api.letsencrypt.org/directory"
   # Required
   #
   entryPoint = "http"
+
+# Use a DNS-01 ACME challenge rather than HTTP-01 challenge.
+# Note: mandatory for wildcard certificate generation.
+#
+# Optional
+#
+# [acme.dnsChallenge]
+
+  # DNS provider used.
+  #
+  # Required
+  #
+  # provider = "digitalocean"
+
+  # By default, the provider will verify the TXT DNS challenge record before letting ACME verify.
+  # If delayBeforeCheck is greater than zero, this check is delayed for the configured duration in seconds.
+  # Useful if internal networks block external DNS queries.
+  #
+  # Optional
+  # Default: 0
+  #
+  # delayBeforeCheck = 0
+
+  # Use following DNS servers to resolve the FQDN authority.
+  #
+  # Optional
+  # Default: empty
+  #
+  # resolvers = ["1.1.1.1:53", "8.8.8.8:53"]
+
+  # Disable the DNS propagation checks before notifying ACME that the DNS challenge is ready.
+  #
+  # NOT RECOMMENDED:
+  # Increase the risk of reaching Let's Encrypt's rate limits.
+  #
+  # Optional
+  # Default: false
+  #
+  # disablePropagationCheck = true
+
+# Domains list.
+# Only domains defined here can generate wildcard certificates.
+# The certificates for these domains are negotiated at traefik startup only.
+#
+# [[acme.domains]]
+#   main = "local1.com"
+#   sans = ["test1.local1.com", "test2.local1.com"]
+# [[acme.domains]]
+#   main = "local2.com"
+# [[acme.domains]]
+#   main = "*.local3.com"
+#   sans = ["local3.com", "test1.test1.local3.com"]
 <% end -%>
 
 
@@ -366,6 +849,8 @@ caServer = "https://acme-staging.api.letsencrypt.org/directory"
 ################################################################
 # Web backend configuration
 ################################################################
+
+# Enable Web Provider.
 [web]
 
 # Web administration port.
@@ -391,8 +876,113 @@ keyFile = "/var/vcap/jobs/traefik/tls/web-backend.key"
 #
 readOnly = <%= p('traefik.web.readonly') %>
 
+# Set the root path for webui and API
+#
+# Deprecated
+# Optional
+#
+# path = "/mypath"
+#
+
+# To enable basic auth on the webui
 [web.auth.basic]
 users = [ "<%= p('traefik.web.basic_auth.username') %>:<%= encode(p('traefik.web.basic_auth.password')) %>" ]
+
+# To enable digest auth on the webui with 2 user/realm/pass: test:traefik:test and test2:traefik:test2
+# [web.auth.digest]
+# users = ["test:traefik:a2688e031edb4be6a3797f3882655c05", "test2:traefik:518845800f9e2bfb1f1f740ec24f074e"]
+# usersFile = "/path/to/.htdigest"
+
+# To enable Traefik to export internal metrics to Prometheus
+# [web.metrics.prometheus]
+
+# Buckets for latency metrics
+#
+# Optional
+# Default: [0.1, 0.3, 1.2, 5]
+# buckets=[0.1,0.3,1.2,5.0]
+
+# DataDog metrics exporter type
+# [web.metrics.datadog]
+
+# DataDog's address.
+#
+# Required
+# Default: "localhost:8125"
+#
+# address = "localhost:8125"
+
+# DataDog push interval
+#
+# Optional
+# Default: "10s"
+#
+# pushinterval = "10s"
+
+# StatsD metrics exporter type
+# [web.metrics.statsd]
+
+# StatD's address.
+#
+# Required
+# Default: "localhost:8125"
+#
+# address = "localhost:8125"
+
+# StatD push interval
+#
+# Optional
+# Default: "10s"
+#
+# pushinterval = "10s"
+
+# InfluxDB metrics exporter type
+# [web.metrics.influxdb]
+
+# InfluxDB's address.
+#
+# Required
+# Default: "localhost:8089"
+#
+# address = "localhost:8089"
+
+# InfluxDB's address protocol (udp or http)
+#
+# Required
+# Default: "udp"
+#
+# protocol = "udp"
+
+# InfluxDB push interval
+#
+# Optional
+# Default: "10s"
+#
+# pushinterval = "10s"
+
+# InfluxDB database used when protocol is http
+#
+# Optional
+# Default: ""
+#
+# database = ""
+
+# InfluxDB retention policy used when protocol is http
+#
+# Optional
+# Default: ""
+#
+# retentionpolicy = ""
+
+# Enable more detailed statistics.
+# [web.statistics]
+
+# Number of recent errors logged.
+#
+# Default: 10
+#
+# recentErrors = 10
+
 <% end -%>
 
 
@@ -401,6 +991,7 @@ users = [ "<%= p('traefik.web.basic_auth.username') %>:<%= encode(p('traefik.web
 ################################################################
 # File backend configuration
 ################################################################
+
 [file]
 
 # Rules file

--- a/jobs/traefik/templates/tls/api-entrypoint.crt
+++ b/jobs/traefik/templates/tls/api-entrypoint.crt
@@ -1,0 +1,1 @@
+<% if_p('traefik.api.tls.cert.certificate') do |cert| %><%= cert %><% end %>

--- a/jobs/traefik/templates/tls/api-entrypoint.key
+++ b/jobs/traefik/templates/tls/api-entrypoint.key
@@ -1,0 +1,1 @@
+<% if_p('traefik.api.tls.cert.private_key') do |key| %><%= key %><% end %>


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.9 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best