### PR TITLE
Bump Traefik to version 1.7.10

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,8 @@
+### Improvements
+
+- Bump Træfik to the latest version 1.7.10 (codename “Maroilles”, a delicious semi-liquid creamy French cheese, yummy!)
+
+### Notice
+
+- The `web` backend and related properties are now deprecated starting with this release version. You must use the `traefik.api.*` properties instead.
+- The `cf-integration.yml` ops file has migrated to using the `traefik.api.*` properties, using a TLS backend instead of an HTTP backend in the previous version.

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.9_linux-amd64.gz:
-  size: 19425802
-  object_id: bee8432a-c9ee-4f77-56fc-5a62358c3382
-  sha: 97680a83acf40152be11b100b5e98307149c7c1c
+traefik/traefik-1.7.10_linux-amd64.gz:
+  size: 19640617
+  sha: c2b3c65672533240f0c5237bd89d3d807016707d

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.10_linux-amd64.gz:
   size: 19640617
+  object_id: cb05e381-ac8c-43e6-6b76-6b7636bada16
   sha: c2b3c65672533240f0c5237bd89d3d807016707d


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.10 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best