### PR TITLE
Bump Traefik to version 1.7.11

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,8 @@
+### Improvements
+
+- Bump Træfik to the latest version 1.7.11
+
+### Notice
+
+- The `web` backend and related properties are deprecated since `v1.3.0`.
+  Please migrate to the `traefik.api.*` properties instead.

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.11_linux-amd64.gz:
   size: 19818271
+  object_id: 7d911a47-7891-4e32-4238-849a625845b2
   sha: sha256:81c8ff3670d0c708439d306a774341ea162df6bc429d4f7cdfab42386b296a92

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.10_linux-amd64.gz:
-  size: 19640617
-  object_id: cb05e381-ac8c-43e6-6b76-6b7636bada16
-  sha: c2b3c65672533240f0c5237bd89d3d807016707d
+traefik/traefik-1.7.11_linux-amd64.gz:
+  size: 19818271
+  sha: sha256:81c8ff3670d0c708439d306a774341ea162df6bc429d4f7cdfab42386b296a92


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.11 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best