### PR TITLE
Bump Traefik to version 1.7.12

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.12_linux-amd64.gz:
   size: 19860042
+  object_id: 651a9f47-b7dd-424c-4aa4-a5a4ed10f8cf
   sha: sha256:2bb0e7e0e76858eaf511d0a3059b7a28a6af8584ff668d64e95e207b4799c75f

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.11_linux-amd64.gz:
-  size: 19818271
-  object_id: 7d911a47-7891-4e32-4238-849a625845b2
-  sha: sha256:81c8ff3670d0c708439d306a774341ea162df6bc429d4f7cdfab42386b296a92
+traefik/traefik-1.7.12_linux-amd64.gz:
+  size: 19860042
+  sha: sha256:2bb0e7e0e76858eaf511d0a3059b7a28a6af8584ff668d64e95e207b4799c75f


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.12 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best