### PR TITLE
Bump Traefik to version 1.7.15

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.14_linux-amd64.gz:
-  size: 23023544
-  object_id: 09a4fb19-d1c0-42f4-467c-8dfb6974aaeb
-  sha: sha256:30dd37f0ccbcf7691db3600a9b5e289658d8d5695858b45a4148dbd2b08b8ec3
+traefik/traefik-1.7.15_linux-amd64.gz:
+  size: 23027380
+  sha: sha256:51bb779d952d77c3d6097810bf597b499da549f6d28a7a4a77677792168fc393

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.15_linux-amd64.gz:
   size: 23027380
+  object_id: fa9eed49-a449-4aaa-490f-d08f12ca5391
   sha: sha256:51bb779d952d77c3d6097810bf597b499da549f6d28a7a4a77677792168fc393


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.15 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best