### PR TITLE
Bump Traefik to version 1.7.18

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.18_linux-amd64.gz:
   size: 23028873
+  object_id: aedc4488-c601-4558-7f0f-a15dc4ecde5e
   sha: sha256:ffa1baefad8234dd094f14f9db93fcbe67c333c2748a3c30a134273f928e48f3

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.14_linux-amd64.gz:
-  size: 23023544
-  object_id: 09a4fb19-d1c0-42f4-467c-8dfb6974aaeb
-  sha: sha256:30dd37f0ccbcf7691db3600a9b5e289658d8d5695858b45a4148dbd2b08b8ec3
+traefik/traefik-1.7.18_linux-amd64.gz:
+  size: 23028873
+  sha: sha256:ffa1baefad8234dd094f14f9db93fcbe67c333c2748a3c30a134273f928e48f3


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.18 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best