### PR TITLE
Bump Traefik to version 1.7.19

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.19_linux-amd64.gz:
   size: 23075492
+  object_id: d3e2ace6-3070-4a5d-4d9f-bf6c159ec655
   sha: sha256:61dc93cc40e907ee11a87ba20c76dbebc3b759021dd1d236acf978544c3d8f96

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.18_linux-amd64.gz:
-  size: 23028873
-  object_id: aedc4488-c601-4558-7f0f-a15dc4ecde5e
-  sha: sha256:ffa1baefad8234dd094f14f9db93fcbe67c333c2748a3c30a134273f928e48f3
+traefik/traefik-1.7.19_linux-amd64.gz:
+  size: 23075492
+  sha: sha256:61dc93cc40e907ee11a87ba20c76dbebc3b759021dd1d236acf978544c3d8f96


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.19 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best