### PR TITLE
Bump Traefik to version 1.7.20

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.19_linux-amd64.gz:
-  size: 23075492
-  object_id: d3e2ace6-3070-4a5d-4d9f-bf6c159ec655
-  sha: sha256:61dc93cc40e907ee11a87ba20c76dbebc3b759021dd1d236acf978544c3d8f96
+traefik/traefik-1.7.20_linux-amd64.gz:
+  size: 23072721
+  sha: sha256:ff72ba82c53569343a855722cbafb94f985ff493273593326a67fd13ff9b552f

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.20_linux-amd64.gz:
   size: 23072721
+  object_id: e5ebce21-eef5-4295-47b9-cf6f574c4ec2
   sha: sha256:ff72ba82c53569343a855722cbafb94f985ff493273593326a67fd13ff9b552f


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.20 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in, and the tests are passing properly. So I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best