### PR TITLE
Bump Consul to version 1.1.0

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,5 @@
 ### Improvements
 
 - Bump Træfik to the latest version [1.7.20](https://github.com/containous/traefik/releases/tag/v1.7.20)
+
+- Bump Consul to v1.1.0 in the `clustering.yml` ops file

--- a/deployment/operations/clustering.yml
+++ b/deployment/operations/clustering.yml
@@ -167,6 +167,6 @@
   type: replace
   value:
     name: gk-consul
-    version: 1.0.0
-    url: https://github.com/gstackio/gk-consul-boshrelease/releases/download/v1.0.0/gk-consul-1.0.0.tgz
-    sha1: 08082c322dec51ffbb995f1d5ea54fdade55dc7b
+    sha1: 87e51bc60282ea6636255b41d3b49bdd5e274dbe
+    url: https://github.com/gstackio/gk-consul-boshrelease/releases/download/v1.1.0/gk-consul-1.1.0.tgz
+    version: 1.1.0


### PR DESCRIPTION
Hi there!

I noticed that the new Consul v1.1.0 is out, so I suggest we use it in the default deployment manifest for this BOSH Release.

Here in this PR, I've updated the deployment manifest.

Let's give it a shot, shall we?

Best