### PR TITLE
Bump Traefik to version 1.7.21

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.21_linux-amd64.gz:
   size: 23076475
+  object_id: 0bfae1a4-b9e7-4819-595a-27078433a448
   sha: sha256:22480645a1d87aeacb653284d734f2428288ed69045e2f278bd95d4425bf8e75

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.20_linux-amd64.gz:
-  size: 23072721
-  object_id: e5ebce21-eef5-4295-47b9-cf6f574c4ec2
-  sha: sha256:ff72ba82c53569343a855722cbafb94f985ff493273593326a67fd13ff9b552f
+traefik/traefik-1.7.21_linux-amd64.gz:
+  size: 23076475
+  sha: sha256:22480645a1d87aeacb653284d734f2428288ed69045e2f278bd95d4425bf8e75


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.21 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best