### PR TITLE
Bump Traefik to version 1.7.24

### DIFF
--- a/ci/traefik-bump/traefik-bump-pipeline.yml
+++ b/ci/traefik-bump/traefik-bump-pipeline.yml
@@ -5,7 +5,7 @@ resource_types:
     type: docker-image
     source:
       repository: swce/keyval-resource
- 
+
 resources:
   - name: kinja-image
     type: docker-image
@@ -109,6 +109,12 @@ jobs:
                     bosh add-blob "../traefik-${latest_traefik_version}_linux-amd64.gz" "traefik/traefik-${latest_traefik_version}_linux-amd64.gz"
 
                     bosh blobs
+
+                    echo "Updating 'scripts/add-blobs.sh' utility."
+                    traefik_sha256=$(bosh blobs --column path --column digest | awk '/traefik\/traefik-[0-9.]+_linux-amd64\.gz/{sub("^sha256:", "", $2); print $2}')
+                    sed -i -re "/TRAEFIK_VERSION=/s/=[0-9.]+\$/=${latest_traefik_version}/" "scripts/add-blobs.sh"
+                    sed -i -re "/TRAEFIK_SHA256=/s/=[0-9a-f]+\$/=${traefik_sha256}/" "scripts/add-blobs.sh"
+                    grep -E -nC 2 "TRAEFIK_(VERSION|SHA256)=" "scripts/add-blobs.sh"
 
                     git config --global "color.ui" "always"
                     git status

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.21_linux-amd64.gz:
-  size: 23076475
-  object_id: 0bfae1a4-b9e7-4819-595a-27078433a448
-  sha: sha256:22480645a1d87aeacb653284d734f2428288ed69045e2f278bd95d4425bf8e75
+traefik/traefik-1.7.24_linux-amd64.gz:
+  size: 20765653
+  sha: sha256:01679e672722d3c419223132823a414bb11d3e44b5039d5c0b3f569fe7da2e3b

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.24_linux-amd64.gz:
   size: 20765653
+  object_id: 7da3a1c1-8f13-4bf3-409f-669df92810c3
   sha: sha256:01679e672722d3c419223132823a414bb11d3e44b5039d5c0b3f569fe7da2e3b

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -2,21 +2,21 @@
 
 set -eo pipefail -u -x
 
-version=1.7.11
-sha256=68332497361cbb694545833c7efb1f569db48a0e5265fad7ca75c91b900c3faa
+TRAEFIK_VERSION=1.7.11
+TRAEFIK_SHA256=68332497361cbb694545833c7efb1f569db48a0e5265fad7ca75c91b900c3faa
 
-if [[ ! -f "traefik-${version}_linux-amd64" && ! -f "traefik-${version}_linux-amd64.gz" ]]; then
-    curl -L "https://github.com/containous/traefik/releases/download/v$version/traefik_linux-amd64" \
-        -o "traefik-${version}_linux-amd64"
-    shasum -a 256 --check <<< "${sha256}  traefik-${version}_linux-amd64"
+if [[ ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64" && ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" ]]; then
+    curl -L "https://github.com/containous/traefik/releases/download/v$TRAEFIK_VERSION/traefik_linux-amd64" \
+        -o "traefik-${TRAEFIK_VERSION}_linux-amd64"
+    shasum -a 256 --check <<< "${TRAEFIK_SHA256}  traefik-${TRAEFIK_VERSION}_linux-amd64"
 fi
 
-if [[ -f "traefik-${version}_linux-amd64" && ! -f "traefik-${version}_linux-amd64.gz" ]]; then
-    gzip -9 "traefik-${version}_linux-amd64"
+if [[ -f "traefik-${TRAEFIK_VERSION}_linux-amd64" && ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" ]]; then
+    gzip -9 "traefik-${TRAEFIK_VERSION}_linux-amd64"
 fi
 
-blob_path="traefik/traefik-${version}_linux-amd64.gz"
+blob_path="traefik/traefik-${TRAEFIK_VERSION}_linux-amd64.gz"
 set +o pipefail
 if ! bosh blobs | grep -q "${blob_path}"; then
-    bosh add-blob "traefik-${version}_linux-amd64.gz" "${blob_path}"
+    bosh add-blob "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" "${blob_path}"
 fi


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.24 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Let's give it a shot, shall we?

Best