### PR TITLE
Bump Traefik to version 1.7.24

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.21_linux-amd64.gz:
-  size: 23076475
-  object_id: 0bfae1a4-b9e7-4819-595a-27078433a448
-  sha: sha256:22480645a1d87aeacb653284d734f2428288ed69045e2f278bd95d4425bf8e75
+traefik/traefik-1.7.24_linux-amd64.gz:
+  size: 20765653
+  sha: sha256:01679e672722d3c419223132823a414bb11d3e44b5039d5c0b3f569fe7da2e3b

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.24_linux-amd64.gz:
   size: 20765653
+  object_id: a85c3bff-1ef9-46cc-6687-9cd4bef73fa1
   sha: sha256:01679e672722d3c419223132823a414bb11d3e44b5039d5c0b3f569fe7da2e3b

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail -u -x
 
-TRAEFIK_VERSION=1.7.11
-TRAEFIK_SHA256=68332497361cbb694545833c7efb1f569db48a0e5265fad7ca75c91b900c3faa
+TRAEFIK_VERSION=1.7.24
+TRAEFIK_SHA256=01679e672722d3c419223132823a414bb11d3e44b5039d5c0b3f569fe7da2e3b
 
 if [[ ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64" && ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" ]]; then
     curl -L "https://github.com/containous/traefik/releases/download/v$TRAEFIK_VERSION/traefik_linux-amd64" \


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.24 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/containous/traefik/releases/tag/v1.7.24
When it's okay to you, let's give it a shot, shall we?

Best