### PR TITLE
Bump Traefik to version 1.7.29

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.26_linux-amd64.gz:
-  size: 20768578
-  object_id: 48c7f84f-4a1e-46a4-6185-1e49e2f98d91
-  sha: sha256:8bfd00c89dee30c0f3de01771f75ce9d49ba5c556534ff9a4095089e28e7ee0b
+traefik/traefik-1.7.29_linux-amd64.gz:
+  size: 17434630
+  sha: sha256:dd6cc46d006dd14d4435cd418848fa7a539f40385134192e958575eae51e26e0

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.29_linux-amd64.gz:
   size: 17434630
+  object_id: 51c862df-d376-483a-77f5-8da685986309
   sha: sha256:dd6cc46d006dd14d4435cd418848fa7a539f40385134192e958575eae51e26e0

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail -u -x
 
-TRAEFIK_VERSION=1.7.26
-TRAEFIK_SHA256=8bfd00c89dee30c0f3de01771f75ce9d49ba5c556534ff9a4095089e28e7ee0b
+TRAEFIK_VERSION=1.7.29
+TRAEFIK_SHA256=dd6cc46d006dd14d4435cd418848fa7a539f40385134192e958575eae51e26e0
 
 if [[ ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64" && ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" ]]; then
     curl -L "https://github.com/containous/traefik/releases/download/v$TRAEFIK_VERSION/traefik_linux-amd64" \


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.29 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/containous/traefik/releases/tag/v1.7.29
When it's okay to you, let's give it a shot, shall we?

Best