### PR TITLE
Bump Traefik to version 1.7.30

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -50,9 +50,9 @@ meta:
 
   bosh:
     stemcell:
-      major: 621
+      major: 0
       cpi: aws-xen-hvm
-      os: ubuntu-xenial
+      os: ubuntu-bionic
     target:        ((bosh-lite-environment))
     cacert:        ((bosh-lite-ca-cert))
     username:      ((bosh-lite-client))

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,14 @@
+### Improvements
+
+- Switch to using Bionic stemcells.
+
+- Bump the [Consul release](https://github.com/gstackio/gk-consul-boshrelease) to v1.6.0 in the `clustering.yml` and `clustering-compiled-release.yml` ops files.
+
+- Improved Concourse pipelines.
+
+
+### Caveats
+
+- Smoke tests require an access to the Internet.
+
+- Clustering mode is experimental: we've experienced situations where no Traefik node is able to acquire the Consul lock in order to access Let's Encrypt cetificates. In such situations, all HTTPS requests requiring a Let's Encrypt certificate are failing, which is pretty bad. We've observed that the Traefik timeout for acquiring Consul lock is too short. Consul does store the expected lock value written by Traefik, but a little too late. So when the value is available, Traefik already has failed at acquiring the lock, and has already started retrying, writing a new value. Traefik won't be able to read the new value back because Consul is still late. Lock acquiring will fail again. Traefik will be able to read this new value only during the next retry. All in all, with enough Let's Encrypt certificates stored (we haven't identified any precise threshold yet), we've observed an infinite loop while Traefik fails at acquiring the Consul lock.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -2,6 +2,8 @@
 
 - Switch to using Bionic stemcells.
 
+- Bump Træfik to the latest version [1.7.30](https://github.com/containous/traefik/releases/tag/v1.7.30).
+
 - Bump the [Consul release](https://github.com/gstackio/gk-consul-boshrelease) to v1.6.0 in the `clustering.yml` and `clustering-compiled-release.yml` ops files.
 
 - Improved Concourse pipelines.

--- a/ci/scripts/export-release
+++ b/ci/scripts/export-release
@@ -12,11 +12,22 @@ set -eu
 #
 
 STEMCELL_CPI=${STEMCELL_CPI:-aws-xen-hvm}
-STEMCELL_OS=${STEMCELL_OS:-ubuntu-xenial}
+STEMCELL_OS=${STEMCELL_OS:-ubuntu-bionic}
 STEMCELL_VERSION=$(cat stemcell/version)
 
-if [[ $(bosh stemcells --json | jq -r ".Tables[0].Rows[] | select(.os == \"${STEMCELL_OS}\") | .version | test(\"${STEMCELL_VERSION}\")" | grep true | uniq) != "true" ]]; then
-  #                        https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-trusty-go_agent?v=3586.7
+stemcells_count=$(
+  bosh stemcells --json \
+    | jq --raw-output \
+        --arg "cpi"     "${STEMCELL_CPI}" \
+        --arg "os"      "${STEMCELL_OS}" \
+        --arg "version" "${STEMCELL_VERSION}" \
+        '[ .Tables[0].Rows[]
+              | select(.os == $os
+                  and (.name | contains($cpi))
+                  and .version == $version)
+          ] | length'
+)
+if [[ ${stemcells_count} -gt 0 ]]; then
   bosh -n upload-stemcell "https://bosh.io/d/stemcells/bosh-${STEMCELL_CPI}-${STEMCELL_OS}-go_agent?v=${STEMCELL_VERSION}"
 fi
 

--- a/ci/scripts/use-compiled-releases
+++ b/ci/scripts/use-compiled-releases
@@ -11,7 +11,7 @@ if [[ -z $(git config --global user.name) ]]; then
   git config --global user.name "${GIT_NAME}"
 fi
 
-STEMCELL_OS=${STEMCELL_OS:-ubuntu-xenial}
+STEMCELL_OS=${STEMCELL_OS:-ubuntu-bionic}
 STEMCELL_VERSION=$(cat stemcell/version)
 
 releases=($(ls -d *compiled-release))

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.26_linux-amd64.gz:
-  size: 20768578
-  object_id: 48c7f84f-4a1e-46a4-6185-1e49e2f98d91
-  sha: sha256:8bfd00c89dee30c0f3de01771f75ce9d49ba5c556534ff9a4095089e28e7ee0b
+traefik/traefik-1.7.30_linux-amd64.gz:
+  size: 17431240
+  sha: sha256:69315c5d75c60432ba78036f2cf8d0bac1248f22cb9097d49dc69e3bb45b7413

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.30_linux-amd64.gz:
   size: 17431240
+  object_id: 6b3dacc0-e0f6-42da-7cca-c79150a4cd64
   sha: sha256:69315c5d75c60432ba78036f2cf8d0bac1248f22cb9097d49dc69e3bb45b7413

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.30_linux-amd64.gz:
   size: 17431240
+  object_id: cf467965-e75a-43bc-5d11-70bbdf944799
   sha: sha256:58c5eb53ed70126122921c3d568b1cfa1e103505f094823f2cecdf5c91976d78

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
 traefik/traefik-1.7.30_linux-amd64.gz:
   size: 17431240
-  object_id: 6b3dacc0-e0f6-42da-7cca-c79150a4cd64
-  sha: sha256:69315c5d75c60432ba78036f2cf8d0bac1248f22cb9097d49dc69e3bb45b7413
+  sha: sha256:58c5eb53ed70126122921c3d568b1cfa1e103505f094823f2cecdf5c91976d78

--- a/deployment/operations/clustering-compiled-release.yml
+++ b/deployment/operations/clustering-compiled-release.yml
@@ -4,9 +4,9 @@
   type: replace
   value:
     name: gk-consul
-    sha1: ff3d5987b770243cf61be49b385cbcab4eafa8d8
+    sha1: 522469dad260e77098e605f94bca14611e5b31bb
     stemcell:
-      os: ubuntu-xenial
-      version: "621.95"
-    url: https://s3.eu-west-3.amazonaws.com/gk-consul-boshrelease/compiled-releases/gk-consul/gk-consul-1.5.0-ubuntu-xenial-621.95-20201223-151234-098087729-20201223151239.tgz
-    version: 1.5.0
+      os: ubuntu-bionic
+      version: "0.28"
+    url: https://s3.eu-west-3.amazonaws.com/gk-consul-boshrelease/compiled-releases/gk-consul/gk-consul-1.6.0-ubuntu-bionic-0.28-20210502-144842-399604816-20210502144843.tgz
+    version: 1.6.0

--- a/deployment/traefik.yml
+++ b/deployment/traefik.yml
@@ -75,16 +75,13 @@ update:
 
 stemcells:
   - alias: default
-    os: ubuntu-xenial
+    os: ubuntu-bionic
     version: latest
 
 releases:
 - name: traefik
-  sha1: f074c19b4d235ef927f78dc07f93ac9b50f44fe0
-  stemcell:
-    os: ubuntu-xenial
-    version: "621.95"
-  url: https://s3.eu-west-3.amazonaws.com/traefik-boshrelease/compiled-releases/traefik/traefik-1.15.0-ubuntu-xenial-621.95-20201223-155156-221627372-20201223155157.tgz
+  sha1: d504c6a5e52056e3d87117d7031c06e21658109e
+  url: https://github.com/gstackio/traefik-boshrelease/releases/download/v1.15.0/traefik-1.15.0.tgz
   version: 1.15.0
 - name: bpm
   sha1: dcf0582d838a73de29da273552ae79ac3098ee8b

--- a/packages/traefik/packaging
+++ b/packages/traefik/packaging
@@ -2,7 +2,7 @@
 
 set -ex
 
-readonly TRAEFIK_VERSION=1.7.26
+readonly TRAEFIK_VERSION=1.7.30
 
 bin_dir="${BOSH_INSTALL_TARGET}/bin"
 mkdir -p "${bin_dir}"

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -3,7 +3,7 @@
 set -eo pipefail -u -x
 
 TRAEFIK_VERSION=1.7.30
-TRAEFIK_SHA256=69315c5d75c60432ba78036f2cf8d0bac1248f22cb9097d49dc69e3bb45b7413
+TRAEFIK_SHA256=58c5eb53ed70126122921c3d568b1cfa1e103505f094823f2cecdf5c91976d78
 
 if [[ ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64" && ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" ]]; then
     curl -L "https://github.com/containous/traefik/releases/download/v$TRAEFIK_VERSION/traefik_linux-amd64" \

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail -u -x
 
-TRAEFIK_VERSION=1.7.26
-TRAEFIK_SHA256=8bfd00c89dee30c0f3de01771f75ce9d49ba5c556534ff9a4095089e28e7ee0b
+TRAEFIK_VERSION=1.7.30
+TRAEFIK_SHA256=69315c5d75c60432ba78036f2cf8d0bac1248f22cb9097d49dc69e3bb45b7413
 
 if [[ ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64" && ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" ]]; then
     curl -L "https://github.com/containous/traefik/releases/download/v$TRAEFIK_VERSION/traefik_linux-amd64" \


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.30 is out, so I suggest we update this BOSH Release with the latest binary available.

Here in this PR, I've pulled that new binary in. I uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/containous/traefik/releases/tag/v1.7.30
When it's okay to you, let's give it a shot, shall we?

Best