### PR TITLE
Bump Traefik to version 1.7.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See the [CONTRIBUTING](CONTRIBUTING.md) docs for more details.
 Author and License
 ------------------
 
-Copyright © 2018-present, Benjamin Gandon
+Copyright © 2018-present, Benjamin Gandon, Gstack
 
 Like the rest of BOSH, the Træfik BOSH release is released under the terms
 of the [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0).

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,12 +1,16 @@
 ### Improvements
 
-- Switch to using Bionic stemcells.
+- Switch to using Jammy stemcells.
 
 - Bump Træfik to the latest version [1.7.33](https://github.com/containous/traefik/releases/tag/v1.7.33).
 
 - Bump the [Consul release](https://github.com/gstackio/gk-consul-boshrelease) to v1.6.0 in the `clustering.yml` and `clustering-compiled-release.yml` ops files.
 
-- Improved Concourse pipelines.
+- Bump BPM to v1.2.19 in the `traefik.yml` deployment manifest.
+
+- Improved Concourse pipelines, re-generated from Cloud Foundry community-maintained [pipeline templates](https://github.com/cloudfoundry-community/pipeline-templates).
+
+- For contributors, provide more documentation and share helper scripts for manual testing and version bumps.
 
 
 ### Caveats

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -2,7 +2,7 @@
 
 - Switch to using Jammy stemcells.
 
-- Bump Træfik to the latest version [1.7.33](https://github.com/containous/traefik/releases/tag/v1.7.33).
+- Bump Træfik to the latest version [1.7.34](https://github.com/containous/traefik/releases/tag/v1.7.34).
 
 - Bump the [Consul release](https://github.com/gstackio/gk-consul-boshrelease) to v1.6.0 in the `clustering.yml` and `clustering-compiled-release.yml` ops files.
 

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
-traefik/traefik-1.7.33_linux-amd64.gz:
-  size: 21828912
-  object_id: da2c6e7d-493a-4a98-541f-d1a7231332de
-  sha: sha256:5d283f7edeca37a091bed4ff0e3f0b25825529bb494fa48ed8f4b96e7181d51f
+traefik/traefik-1.7.34_linux-amd64.gz:
+  size: 21839111
+  sha: sha256:5780529dd43c993a968d33e3409f08dfde549d522e2f35b86d10be097efb25b3

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,4 @@
 traefik/traefik-1.7.34_linux-amd64.gz:
   size: 21839111
+  object_id: 4110c002-a838-4730-54e9-d9a8f3464ee1
   sha: sha256:5780529dd43c993a968d33e3409f08dfde549d522e2f35b86d10be097efb25b3

--- a/packages/traefik/packaging
+++ b/packages/traefik/packaging
@@ -2,7 +2,7 @@
 
 set -ex
 
-readonly TRAEFIK_VERSION=1.7.33
+readonly TRAEFIK_VERSION=1.7.34
 
 bin_dir="${BOSH_INSTALL_TARGET}/bin"
 mkdir -p "${bin_dir}"

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail -u -x
 
-TRAEFIK_VERSION=1.7.33
-TRAEFIK_SHA256=5d283f7edeca37a091bed4ff0e3f0b25825529bb494fa48ed8f4b96e7181d51f
+TRAEFIK_VERSION=1.7.34
+TRAEFIK_SHA256=5780529dd43c993a968d33e3409f08dfde549d522e2f35b86d10be097efb25b3
 
 if [[ ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64" && ! -f "traefik-${TRAEFIK_VERSION}_linux-amd64.gz" ]]; then
     curl -L "https://github.com/containous/traefik/releases/download/v$TRAEFIK_VERSION/traefik_linux-amd64" \


### PR DESCRIPTION
Hi there!

I noticed that the new Traefik v1.7.34 is out, so I suggest we update this BOSH Release with the latest artifact available.

Here in this PR, I've pulled that new artifact in. I've already uploaded the blob to the release blobstore, and here is the result.

Don't hesitate to have a look at the release notes: https://github.com/containous/traefik/releases/tag/v1.7.34
When it's okay to you, let's give it a shot, shall we?

Best